### PR TITLE
user model test : aggregate_failures を追記

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,24 +1,39 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  context "account を指定しているとき" do
+  context "password を指定しているとき" do
     it "ユーザーが作られる" do
       user = build(:user)
       expect(user).to be_valid
     end
   end
 
-  context "account を指定していないとき" do # rubocop:disable RSpec/RepeatedExampleGroupBody
+  context "password を指定していないとき" do
     it "ユーザー作成に失敗する" do
+      user = build(:user, password: nil)
+      aggregate_failures "最後まで通過" do
+        expect(user).to be_invalid
+        expect(user.errors.details[:password][0][:error]).to eq :blank
+      end
     end
   end
 
-  context "まだ同じ名前の account が存在しないとき" do
+  context "email を指定していないとき" do
+    it "ユーザー作成に失敗する" do
+      user = build(:user, email: nil)
+      aggregate_failures "最後まで通過" do
+        expect(user).to be_invalid
+        expect(user.errors.details[:email][0][:error]).to eq :blank
+      end
+    end
+  end
+
+  context "まだ同じ名前の name が存在しないとき" do
     it "ユーザーが作られる" do
     end
   end
 
-  context "すでに同じ名前の account が存在しているとき" do # rubocop:disable RSpec/RepeatedExampleGroupBody
+  context "すでに同じ名前の name が存在しているとき" do
     it "ユーザー作成に失敗する" do
     end
   end


### PR DESCRIPTION
## About
* `aggregate_failures` を追記
  - Example has too many expectations の対応

## 📓 Note 
> これを使うと失敗の有無にかかわらずブロックで囲まれたエクスペクテーションをすべて実行してくれます。

参考URL:
[1. 特定のエクスペクテーション群をまとめて検証できる（aggregate_failures メソッド）](https://qiita.com/jnchito/items/3a590480ee291a70027c#1-%E7%89%B9%E5%AE%9A%E3%81%AE%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%9A%E3%82%AF%E3%83%86%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E7%BE%A4%E3%82%92%E3%81%BE%E3%81%A8%E3%82%81%E3%81%A6%E6%A4%9C%E8%A8%BC%E3%81%A7%E3%81%8D%E3%82%8Baggregate_failures-%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89)