### PR TITLE
aggregate_failuresを 対象テストのtag付けで対応した

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,21 +10,17 @@ RSpec.describe User, type: :model do
 
   context "password を指定していないとき" do
     it "ユーザー作成に失敗する" do
-      user = build(:user, password: nil)
-      aggregate_failures "最後まで通過" do
-        expect(user).to be_invalid
-        expect(user.errors.details[:password][0][:error]).to eq :blank
-      end
+      user = build(:user, password: nil)  
+      expect(user).to be_invalid
+      expect(user.errors.details[:password][0][:error]).to eq :blank
     end
   end
 
   context "email を指定していないとき" do
     it "ユーザー作成に失敗する" do
       user = build(:user, email: nil)
-      aggregate_failures "最後まで通過" do
-        expect(user).to be_invalid
-        expect(user.errors.details[:email][0][:error]).to eq :blank
-      end
+      expect(user).to be_invalid
+      expect(user.errors.details[:email][0][:error]).to eq :blank
     end
   end
 
@@ -39,13 +35,10 @@ RSpec.describe User, type: :model do
 
   context "すでに同じ email が存在しているとき" do
     before { create(:user, email: "foo@foo.xxx") }
-
     it "ユーザー作成に失敗する" do
       user = build(:user, email: "foo@foo.xxx")
-      aggregate_failures "最後まで通過" do
-        expect(user).to be_invalid
-        expect(user.errors.details[:email][0][:error]).to eq :taken
-      end
+      expect(user).to be_invalid
+      expect(user.errors.details[:email][0][:error]).to eq :taken
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe User, type: :model do
   context "password を指定していないとき" do
     it "ユーザー作成に失敗する", :aggregate_failures do
       user = build(:user, password: nil)
-      expect(user).to be_valid
+      expect(user).to be_invalid
       expect(user.errors.details[:password][0][:error]).to eq :blank
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe User, type: :model do
   end
 
   context "password を指定していないとき" do
-    it "ユーザー作成に失敗する" do
-      user = build(:user, password: nil)  
-      expect(user).to be_invalid
+    it "ユーザー作成に失敗する", :aggregate_failures do
+      user = build(:user, password: nil)
+      expect(user).to be_valid
       expect(user.errors.details[:password][0][:error]).to eq :blank
     end
   end
 
   context "email を指定していないとき" do
-    it "ユーザー作成に失敗する" do
+    it "ユーザー作成に失敗する", :aggregate_failures do
       user = build(:user, email: nil)
       expect(user).to be_invalid
       expect(user.errors.details[:email][0][:error]).to eq :blank
@@ -35,7 +35,8 @@ RSpec.describe User, type: :model do
 
   context "すでに同じ email が存在しているとき" do
     before { create(:user, email: "foo@foo.xxx") }
-    it "ユーザー作成に失敗する" do
+
+    it "ユーザー作成に失敗する", :aggregate_failures do
       user = build(:user, email: "foo@foo.xxx")
       expect(user).to be_invalid
       expect(user.errors.details[:email][0][:error]).to eq :taken

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,7 +91,4 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #  Kernel.srand config.seed
-  config.define_derived_metadata do |meta|
-    meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,4 +91,7 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #  Kernel.srand config.seed
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
+  end
 end


### PR DESCRIPTION
## About
* spec_helper側で設定すれば、同じ記述を一括で定義できる
