### PR TITLE
aggregate_failuresを`spec_helper.rb`に設定

### DIFF
--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -47,8 +47,7 @@ RSpec/InstanceVariable:
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
-  # AggregateFailuresByDefault: true
-  Enabled: true
+  Enabled: false
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe User, type: :model do
   end
 
   context "password を指定していないとき" do
-    it "ユーザー作成に失敗する", :aggregate_failures do
+    it "ユーザー作成に失敗する" do
       user = build(:user, password: nil)
       expect(user).to be_invalid
       expect(user.errors.details[:password][0][:error]).to eq :blank
@@ -17,7 +17,7 @@ RSpec.describe User, type: :model do
   end
 
   context "email を指定していないとき" do
-    it "ユーザー作成に失敗する", :aggregate_failures do
+    it "ユーザー作成に失敗する" do
       user = build(:user, email: nil)
       expect(user).to be_invalid
       expect(user.errors.details[:email][0][:error]).to eq :blank
@@ -36,7 +36,7 @@ RSpec.describe User, type: :model do
   context "すでに同じ email が存在しているとき" do
     before { create(:user, email: "foo@foo.xxx") }
 
-    it "ユーザー作成に失敗する", :aggregate_failures do
+    it "ユーザー作成に失敗する" do
       user = build(:user, email: "foo@foo.xxx")
       expect(user).to be_invalid
       expect(user.errors.details[:email][0][:error]).to eq :taken

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,4 +91,11 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #  Kernel.srand config.seed
+  # config.define_derived_metadata do |meta|
+  #   meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
+  # end
+
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
 end


### PR DESCRIPTION
## About
* aggregate_failuresをspec_helperに設定

## 📓 Note
これはサポート切れで上手くいかないの Warning
- config/rubocop/rspec.yml
``` yml
RSpec/MultipleExpectations:
  AggregateFailuresByDefault: false
```
こうする
``` yml
RSpec/MultipleExpectations:
  Enabled: false
```
