### PR TITLE
Article model の has_many を修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -74,11 +74,18 @@ module Api::V1
       # }
       # -----------------------------------------------------
 
-      # インスタンスを model から作成する
-      article = current_user.article.create!(article_params)
+      # article = current_user.article.create!(article_params)
+      # >>> User >> has_many: article -> 複数系で書いてなかった
+      # >>>                   articles に修正
 
-      # 模範は articles. :... 何故??
-      # article = current_user.articles.create!(article_params)
+      # NoMethodError (undefined method `articles' for #<User:0x00007f9c7795c9d0>
+      #   Did you mean?  article
+      #                  article=):
+
+      #   app/controllers/api/v1/articles_controller.rb:81:in `create'
+
+      # インスタンスを model から作成する
+      article = current_user.articles.create!(article_params)
 
       # インスタンスを DB に保存する >>> なくてもDB保存される
       # article.save!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,11 +36,13 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  # TODO: gem: のこと??
   include DeviseTokenAuth::Concerns::User
   validates :name, :password, presence: true
   validates :email, presence: true, uniqueness: { case_sensitive: false }
 
-  has_many :article, dependent: :destroy
+  has_many :articles, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -6,7 +6,7 @@ require "rails_helper"
 # type: request の test をするにで :requestとする
 RSpec.describe "Api::V1::Articles", type: :request do
   # test対象のurl
-  describe "GET /article" do
+  describe "GET /articles" do
     # status 200 の確認　
     subject { get(api_v1_articles_path) }
 


### PR DESCRIPTION
## About
* has_many article と単体系で書いていたので複数系に修正

## 📓 Note
* `article controller` の呼び出しの時に複数系でErrorが出たので気づいた

``` bash
 NoMethodError (undefined method `articles' for #<User:0x00007f9c7795c9d0>
 Did you mean?  article
                  article=):
 app/controllers/api/v1/articles_controller.rb:81:in `create'
```

* このErrorで、modelからの呼ばれ方がなんとなくわかった
``` ruby
article = current_user.articles.create!(article_params)
```
userが複数の記事を保持しているから、has_many >> そこからインスタンスを生成している