### PR TITLE
記事更新のテストを実装

### DIFF
--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -71,3 +71,7 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+# context ごとに let! を使い分けたい場合があるため無効に
+RSpec/LetSetup:
+  Enabled: false


### PR DESCRIPTION
## About
* 記事更新のテスト実装

## 📓 Note
* 記事更新出来ない時の実装が抜けていた
* let の記述位置が模範とは違った.
``` ruby
>>> この記述が, contextの中だった.  可読性の問題なのか?? と思っている
 # 3.articleの定義 >>> currnt_user_stubを探す
 let(:article) { create(:article, user: current_user_stub) }
```