### PR TITLE
新規登録正常系テストを実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -30,7 +30,6 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
       #         "updated_at": "2020-11-03T03:33:40.019Z"
       #      }
       #   }
-
       params.permit(:name, :email, :password, :password_confirmation)
     end
 

--- a/spec/requests/api/v1/auth/registrations_request_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_request_spec.rb
@@ -1,6 +1,32 @@
 require "rails_helper"
 
+# $ bundle exec rspec spec/requests/api/v1/auth/registrations_request_spec.rb --tag focus
+
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  it "新規登録ができる" do
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "新規登録するUser情報が正しい時" do
+      let(:params) { attributes_for(:user) }
+
+      it "新規登録ができる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res["data"]["id"]).to eq User.last.id
+        expect(res["data"]["email"]).to eq User.last.email
+        expect(res["data"]["name"]).to eq params[:name]
+      end
+    end
+
+    # context "新規登録するUserのpass認証が違う時" do
+    #   it "do Error" do
+    #   end
+    # end
+
+    # context "新規登録するUserのEmailがすでに登録されている時" do
+    #   it "do Error" do
+    #   end
+    # end
   end
 end


### PR DESCRIPTION
## About
* 新規登録：正常時のテストを実装

## 📓 Note
* routesの認識があまく. Error原因の追求に2日以上要した.
``` bash
NameError:
   undefined local variable or method `api_v1_auth_registration_path'  ...
```