### PR TITLE
新規登録異常系テスト実装

### DIFF
--- a/spec/requests/api/v1/auth/registrations_request_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
     subject { post(api_v1_user_registration_path, params: params) }
 
     context "新規登録するUser情報が正しい時" do
-      let(:params) { attributes_for(:user) }
+      let(:params) { attributes_for(:user, password: 123456, password_confirmation: 123456) }
 
       it "新規登録ができる" do
         subject
@@ -19,14 +19,23 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       end
     end
 
-    # context "新規登録するUserのpass認証が違う時" do
-    #   it "do Error" do
-    #   end
-    # end
+    context "新規登録するUserのpass認証が違う時" do
+      let(:params) { attributes_for(:user, password: 123456, password_confirmation: 123457) }
 
-    # context "新規登録するUserのEmailがすでに登録されている時" do
-    #   it "do Error" do
-    #   end
-    # end
+      it "do Error" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "新規登録するUserのEmailがすでに登録されている時" do
+      let!(:user) { create(:user, email: "Exsample@xxx.com") }
+      let(:params) { attributes_for(:user, email: "Exsample@xxx.com") }
+
+      it "do Error" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/auth/registrations_request_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_request_spec.rb
@@ -6,19 +6,19 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do
     subject { post(api_v1_user_registration_path, params: params) }
 
-    context "新規登録 response header 情報が正しい時" do
+    context "新規登録 response header 情報が確認できた時" do
       # """ 正確な header 情報（トークン）のレスポンスを確認する """
 
       let(:params) { attributes_for(:user) }
 
-      # 新規登録画面に必要な情報を入力して返ってきた情報の一部
-      let(:token) { response.headers["access-token"] }
-      let(:uid) { response.headers["uid"] }
-
       it "新規登録ができる" do
         subject
-        expect(token).not_to be_nil
-        expect(uid).to eq params[:email]
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["token-type"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to eq params[:email]
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/requests/api/v1/auth/registrations_request_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_request_spec.rb
@@ -6,7 +6,25 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do
     subject { post(api_v1_user_registration_path, params: params) }
 
+    context "新規登録 response header 情報が正しい時" do
+      # """ 正確な header 情報（トークン）のレスポンスを確認する """
+
+      let(:params) { attributes_for(:user) }
+
+      # 新規登録画面に必要な情報を入力して返ってきた情報の一部
+      let(:token) { response.headers["access-token"] }
+      let(:uid) { response.headers["uid"] }
+
+      it "新規登録ができる" do
+        subject
+        expect(token).not_to be_nil
+        expect(uid).to eq params[:email]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     context "新規登録するUser情報が正しい時" do
+      # """ このテストはただ, リクエスト情報の確認をしてるだけ """
       let(:params) { attributes_for(:user, password: 123456, password_confirmation: 123456) }
 
       it "新規登録ができる" do


### PR DESCRIPTION
## About
 
### 異常系
 - User認証のpassが違う時
 - 既に登録されているemailの場合

## 📓 Note
* 正常系でpassの正誤が取れているかもっというところ入れた
``` ruby
line10 +   let(:params) { attributes_for(:user, password: 123456, password_confirmation: 123456) }
```