### PR TITLE
既存 APIの修正 記事CRUD処理

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,11 +1,8 @@
 module Api::V1
   # base_api_controller を継承
-
-  # before_action :article_params
-  # before_action :authenticate_api_v1_user!, only: [:create, :update, :destory]
-  # protect_from_forgery with: :null_session
-
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
+
     def index
       # """ 記事の一覧を表示 """
       #  GET: http://localhost:3000/api/v1/articles
@@ -30,7 +27,6 @@ module Api::V1
       # インスタンスを model から作成する
       # create!: new, saveを同時にしている: １行で処理を済ませる時は良い
       article = current_user.articles.create!(article_params)
-      # article = current_api_v1_user.articles.create!(article_params)
 
       # json として値を返す
       render json: article

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,28 +1,13 @@
 class Api::V1::BaseApiController < ApplicationController
-  # sgin_in していない場合常に 401 Error を返す
-  # before_action :authenticate_user!
-  # before_action :authenticate_api_v1_user!, only: [:create, :update, :destory]
-
-  # current_api_v1_user
-  # authenticate_api_v1_user!
-  # user_api_v1_signed_in?
-
   def current_user
-    # """ 認証Userをインスタン変数に格納
-    # currnet_api_v1_user()
-    #
-    #
-    # """
+    # """ 認証Userをインスタン変数に格納 """
     @current_user ||= current_api_v1_user
   end
 
   def authenticate_user!
     # """ ログインしていないと使えない API
     # 記事: 作成, 更新, 削除
-
     # 認証Userであるか。 認証Userでなければ 401 """
-
-    # tokenがされていない場合
   end
 
   def user_signed_in?


### PR DESCRIPTION
## About
* `devise_token_auth` の `helper method`を使用。 token認証でCRUD処理できるよに修正
* 記事作成に失敗するテストを保留にしていたが, 作成

## 📓 Note 
* request のテストは, 期待した結果が返ってくるかのテストであり, `subject` をテストすること