### PR TITLE
add: status column Articles model

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("drafts"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -23,4 +24,6 @@ class Article < ApplicationRecord
 
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
+
+  enum status: { drafts: 0, Publish: 1 }
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -25,5 +25,5 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  enum status: { drafts: 0, Publish: 1 }
+  enum status: { drafts: 0, publish: 1 }
 end

--- a/db/migrate/20201204122738_add_status_to_articles.rb
+++ b/db/migrate/20201204122738_add_status_to_articles.rb
@@ -1,0 +1,6 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    # after: <column name>  ->> MySQLのみ, Postgres, sqliteは末尾に反映される
+    add_column :articles, :status, :integer, null: false, default: 0, after: :body
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_07_095103) do
+ActiveRecord::Schema.define(version: 2020_12_04_122738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2020_10_07_095103) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("drafts"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("drafts"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -41,9 +41,8 @@ RSpec.describe "Api::V1::Articles", type: :request do
       it "指定したid の記事を表示できる" do
         subject
         res = JSON.parse(response.body)
-
         expect(response).to have_http_status(:ok)
-        expect(res.keys).to eq ["id", "title", "body", "user_id", "created_at", "updated_at"]
+        expect(res.keys).to eq ["id", "title", "body", "user_id", "created_at", "updated_at", "status"]
 
         # 4: article.xx を明記
         expect(res["id"]).to eq article.id
@@ -81,7 +80,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect { subject }.to change { Article.count }.by(1)
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
-        expect(res.keys).to eq ["id", "title", "body", "user_id", "created_at", "updated_at"]
+        expect(res.keys).to eq ["id", "title", "body", "user_id", "created_at", "updated_at", "status"]
         expect(res["user_id"]).to eq current_user.id
         expect(res["title"]).to eq params[:article][:title]
         expect(res["body"]).to eq params[:article][:body]


### PR DESCRIPTION
## About
* Articles model に記事の下書き・公開の status カラムを追加
  * `default: 0` 下書きで作成されるように設定

## 📓 Note
``` ruby
# add status column 
$ bundle exec rails d migration AddStatusToArticles status:integer
```