### PR TITLE
Testを追加 ( Article model 下書き機能)

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -66,7 +66,7 @@ module Api::V1
       def article_params
         # """ strong parameter """
         # 引数に修正可能な column を指定する
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -25,5 +25,5 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  enum status: { drafts: 0, publish: 1 }
+  enum status: { drafts: 0, published: 1 }
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -24,5 +24,13 @@ FactoryBot.define do
     body { Faker::Lorem.sentence }
     # association :user, factory: :user の略
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -21,39 +21,70 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  context "titleがある時" do
-    let(:article) { create(:article) }
+  describe "正常系" do
+    context "titleがある時" do
+      let(:article) { create(:article) }
 
-    it "記事を投稿できる" do
-      expect(article).to be_valid
+      it "記事を投稿できる" do
+        expect(article).to be_valid
+      end
+    end
+
+    context "記事作成で, statusを指定しない時" do
+      let(:article) { create(:article) }
+
+      it "default で下書き記事が作成される" do
+        expect(article).to be_valid
+        expect(article.status).to eq "drafts"
+      end
+    end
+
+    context "下書き選択で記事を作成した時" do
+      let(:article) { create(:article, :drafts) }
+
+      it "下書き記事が作成される" do
+        expect(article).to be_valid
+        expect(article.status).to eq "drafts"
+      end
+    end
+
+    context "公開記事で作成する時" do
+      let(:article) { create(:article, status: :published) }
+
+      it "公開記事で作成される" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
     end
   end
 
-  context "title が 10文字より少ない時" do
-    let(:article) { build(:article, title: "*" * 9) }
+  describe "異常系" do
+    context "title が 10文字より少ない時" do
+      let(:article) { build(:article, title: "*" * 9) }
 
-    it "記事の投稿に失敗する" do
-      expect(article).to be_invalid
-      expect(article.errors.details[:title][0][:error]).to eq :too_short
+      it "記事の投稿に失敗する" do
+        expect(article).to be_invalid
+        expect(article.errors.details[:title][0][:error]).to eq :too_short
+      end
     end
-  end
 
-  context "title が 50文字より多い時" do
-    let(:article) { build(:article, title: "*" * 51) }
+    context "title が 50文字より多い時" do
+      let(:article) { build(:article, title: "*" * 51) }
 
-    it "記事の投稿に失敗する" do
-      expect(article).to be_invalid
-      expect(article.errors.details[:title][0][:error]).to eq :too_long
+      it "記事の投稿に失敗する" do
+        expect(article).to be_invalid
+        expect(article.errors.details[:title][0][:error]).to eq :too_long
+      end
     end
-  end
 
-  context "titleがない時" do
-    let(:article) { build(:article, title: nil) }
+    context "titleがない時" do
+      let(:article) { build(:article, title: nil) }
 
-    it "記事の投稿に失敗する" do
-      expect(article).to be_invalid
-      expect(article.errors.details[:title][0][:error]).to eq :blank
-      expect(article.errors.details[:title][1][:error]).to eq :too_short
+      it "記事の投稿に失敗する" do
+        expect(article).to be_invalid
+        expect(article.errors.details[:title][0][:error]).to eq :blank
+        expect(article.errors.details[:title][1][:error]).to eq :too_short
+      end
     end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Article, type: :model do
     end
 
     context "記事作成で, statusを指定しない時" do
-      let(:article) { create(:article) }
+      let(:article) { build(:article) }
 
       it "default で下書き記事が作成される" do
         expect(article).to be_valid
@@ -40,7 +40,7 @@ RSpec.describe Article, type: :model do
     end
 
     context "下書き選択で記事を作成した時" do
-      let(:article) { create(:article, :drafts) }
+      let(:article) { build(:article, :drafts) }
 
       it "下書き記事が作成される" do
         expect(article).to be_valid
@@ -49,7 +49,7 @@ RSpec.describe Article, type: :model do
     end
 
     context "公開記事で作成する時" do
-      let(:article) { create(:article, status: :published) }
+      let(:article) { build(:article, status: :published) }
 
       it "公開記事で作成される" do
         expect(article).to be_valid

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
+
+    context "公開記事である場合" do
+      it "公開一覧に表示される" do
+      end
+    end
+
+    context "下書き記事である場合" do
+      it "公開一覧に表示されない" do
+      end
+    end
   end
 
   describe "POST /articles" do
@@ -84,6 +94,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect(res["user_id"]).to eq current_user.id
         expect(res["title"]).to eq params[:article][:title]
         expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq "drafts"
       end
     end
 


### PR DESCRIPTION
## About

* 正常系のテストを追加
* FactoryBotに`trait`を使用し記事との紐付け
* 変数名を`published` 公開済に修正

## 📓 Note
* strong parameterにstatusを追記
   Postman で下書き・公開の切り替えを確かめたくて追加した
* requests のtestはテンプレだけ追加したので後ほど