### PR TITLE
routes: draftが優先になるよう修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,12 +14,12 @@ Rails.application.routes.draw do
         registrations: "api/v1/auth/registrations",
         sessions: "api/v1/auth/sessions",
       }
+      namespace :articles do
+        resources :draft, only: [:index, :show]
+      end
+
       # REST API 紐付ける
       resources :articles
-
-      namespace :articles do
-        resources :draft
-      end
     end
   end
 end


### PR DESCRIPTION
## About
* routes : index API を叩いたら articles が優先され,` {'id': 'draft'}`のようなErrorになったので修正

## 📓 Note
```bash
# API cmd
http://localhost:3000/api/v1/articles/draft
```