### PR TITLE
下書き/公開記事 ActiveRecodeの呼び出し記述を修正

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -6,7 +6,7 @@ module Api::V1
       # """ 自身の下書き一覧が確認できる処理 """"
       # GET: http://localhost:3000/api/v1/articles/draft
 
-      articles = current_user.articles.where(status: 0).order(updated_at: :desc)
+      articles = current_user.articles.draft.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
@@ -14,21 +14,8 @@ module Api::V1
       # """ 自身の下書き１レコードが確認できる処理 """
       # GET: http://localhost:3000/api/v1/articles/draft/:id
 
-      article = current_user.articles.find(params[:id])
-
-      # TODO: 登録されていないレコードが指定された時, Not Found で返すメッセージ
-
-      # 公開記事が指定された場合は Not Found で返す
-      if article["status"] == "published"
-        response.status = 404
-        render json: 404
-      end
-
-      # 下書き指定記事のみ表示
-      if article["status"] == "draft"
-        # render json: article, each_serializer: Api::V1::ArticlePreviewSerializer
-        render json: article, serializer: Api::V1::ArticleSerializer
-      end
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
   end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,7 +8,7 @@ module Api::V1
       #  GET: http://localhost:3000/api/v1/articles
 
       # 公開一覧記事のみ表示 降順 sort: :desc
-      articles = Article.where(status: 1).order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
@@ -16,20 +16,8 @@ module Api::V1
       # """ 記事の詳細をみる """
       #  GET: http://localhost:3000/api/v1/articles/2
 
-      article = Article.where(status: 1).find(params[:id])
-
-      # TODO: 登録されていないレコードが指定された時, Not Found で返すメッセージ
-
-      # 非公開記事が指定された場合は Not Found で返す
-      if article["status"] == "draft"
-        response.status = 404
-        render json: 404
-      end
-
-      # 公開された指定記事のみ表示
-      if article["status"] == "published"
-        render json: article, serializer: Api::V1::ArticleSerializer
-      end
+      article = Article.published.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def create

--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -6,7 +6,7 @@ module Api::V1
       # """ 自身公開一覧が確認できる処理 """"
       # GET: http://localhost:3000/api/v1/current/articles
 
-      articles = current_user.articles.where(status: 1).order(updated_at: :desc)
+      articles = current_user.articles.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
   end

--- a/spec/requests/api/v1/articles/drafts_request_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-# $ bundle exec rspec spec/requests/api/v1/articles/draft_request_spec.rb --tag focus
+# $ bundle exec rspec spec/requests/api/v1/articles/drafts_request_spec.rb --tag focus
 RSpec.describe "Api::V1::Articles::Drafts", type: :request do
   describe "GET /api/v1/articles/drafts" do
     subject { get(api_v1_articles_drafts_path, headers: headers) }
@@ -72,16 +72,6 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
           expect(res["status"]).to eq "draft"
 
           expect(response).to have_http_status(:ok)
-        end
-      end
-
-      context "自身の指定した id の記事が公開記事の時" do
-        let(:article) { create(:article, :published, user: current_user) }
-        let(:article_id) { article.id }
-
-        it "Not Found で返す" do
-          subject
-          expect(response).to have_http_status(:not_found)
         end
       end
 

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -60,17 +60,6 @@ RSpec.describe "Api::V1::Articles", type: :request do
           expect(res["updated_at"]).to be_present
         end
       end
-
-      # context "下書き記事である場合" do
-      #   let(:article) { create(:article, :draft) }
-      #   let(:article_id) { article.id }
-
-      #   fit "status 404で返す" do
-      #     subject
-      #     expect { subject }.to raise_error ActiveRecord::RecordNotFound
-      #     # expect(response).to have_http_status(:not_found)
-      #   end
-      # end
     end
 
     describe "異常系" do


### PR DESCRIPTION
## About
* 記事表示の呼び出す気記述を修正
  * status: 1    ❌
  * published ⭕️

## 📓 Note 
* その１行で何をしているかが理解出来ていること.
* `status: 1` では、model まで見に行かないと何を呼び出しているのか。がわからない 
* 合わせて、if .. end の下書き見つからんなどの切り分け処理も必要ない
* そもそも、`status 404` の処理ではない