### PR TITLE
いいね数の制限づけ:1記事につき1回のみ

### DIFF
--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -22,4 +22,7 @@
 class ArticleLike < ApplicationRecord
   belongs_to :user
   belongs_to :article
+
+  # 1記事に１いいねのみ
+  validates :article_id, uniqueness: { scope: :user_id } # rubocop:disable Rails/UniqueValidationWithoutIndex:
 end


### PR DESCRIPTION
## About
* いいね数の制限づけ、一記事 **1いいね**のみ
* rubocop Error の解消方法が分からないので、回避コメントで対応した

## Rubcope Error Message
> Rails/UniqueValidationWithoutIndex: Uniqueness validation should be with a unique index.